### PR TITLE
Adding perf parameters, custom ec and modifying api invoker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ generated/src
 client/src
 client/project/build.properties
 .env
+snapshots

--- a/build.sbt
+++ b/build.sbt
@@ -88,7 +88,6 @@ lazy val models = project
   .in(file("models"))
   .settings(
     name                := "interop-be-agreement-management-models",
-    scalacOptions       := Seq(),
     libraryDependencies := Dependencies.Jars.models,
     scalafmtOnCompile   := true,
     Docker / publish    := {},

--- a/models/src/main/scala/it/pagopa/interop/agreementmanagement/model/agreement/PersistentAgreement.scala
+++ b/models/src/main/scala/it/pagopa/interop/agreementmanagement/model/agreement/PersistentAgreement.scala
@@ -1,7 +1,5 @@
 package it.pagopa.interop.agreementmanagement.model.agreement
 
-import it.pagopa.interop.commons.utils.service.{OffsetDateTimeSupplier, UUIDSupplier}
-import cats.implicits._
 import java.time.OffsetDateTime
 import java.util.UUID
 

--- a/models/src/main/scala/it/pagopa/interop/agreementmanagement/model/agreement/PersistentAgreementState.scala
+++ b/models/src/main/scala/it/pagopa/interop/agreementmanagement/model/agreement/PersistentAgreementState.scala
@@ -1,7 +1,5 @@
 package it.pagopa.interop.agreementmanagement.model.agreement
 
-import it.pagopa.interop.agreementmanagement.model._
-
 object PersistentAgreementState
 sealed trait PersistentAgreementState
 case object Pending   extends PersistentAgreementState

--- a/src/main/resources/application-standalone.conf
+++ b/src/main/resources/application-standalone.conf
@@ -55,3 +55,10 @@ interop-commons {
     }
   }
 }
+
+futures-dispatcher {
+  type = Dispatcher
+  executor = "thread-pool-executor"
+  throughput = 1
+  thread-pool-executor.fixed-pool-size-min = 4
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -18,3 +18,36 @@ interop-commons {
     }
   }
 }
+
+akka.http {
+  server {
+    pipelining-limit = 128 # default 1
+    pipelining-limit = ${?PIPELINING_LIMIT}
+    backlog = 100 # default 100
+    backlog = ${?BACKLOG_SIZE}
+  }
+
+  host-connection-pool {
+    max-connections = 16
+    max-connections = ${?CONNECTION_POOL_MAX_CONNECTIONS}
+    min-connections = 2
+    min-connections = ${?CONNECTION_POOL_MIN_CONNECTIONS}
+    max-open-requests = 256
+    max-open-requests = ${?CONNECTION_POOL_MAX_OPEN_REQUESTS}
+  }
+}
+
+futures-dispatcher {
+  type = Dispatcher
+  executor = "thread-pool-executor"
+  thread-pool-executor {
+    core-pool-size-min = 4
+    core-pool-size-factor = 1.0
+    core-pool-size-max = 16
+    max-pool-size-min = 4
+    max-pool-size-factor = 1.0
+    max-pool-size-max = 16
+  }
+  throughput = 1
+  throughput = ${?BLOCKING_DISPATCHER_THROUGHPUT}
+}

--- a/template/scala-akka-http-client/apiInvoker.mustache
+++ b/template/scala-akka-http-client/apiInvoker.mustache
@@ -27,11 +27,11 @@ import it.pagopa.interop.commons.logging.{CanLogContextFields, ContextFieldsToLo
 import java.util.UUID
 
 object ApiInvoker {
-  def apply()(implicit system: ActorSystem, ec: ExecutionContext): ApiInvoker =
-    apply(DefaultFormats ++ Serializers.all)
-  def apply(serializers: Iterable[Serializer[_]])(implicit system: ActorSystem, ec: ExecutionContext): ApiInvoker =
-    apply(DefaultFormats ++ Serializers.all ++ serializers)
-  def apply(formats: Formats)(implicit system: ActorSystem, ec: ExecutionContext): ApiInvoker = new ApiInvoker(formats)
+  def apply(ec: ExecutionContextExecutor)(implicit system: ActorSystem): ApiInvoker =
+    apply(DefaultFormats ++ Serializers.all, ec)
+  def apply(serializers: Iterable[Serializer[_]], ec: ExecutionContextExecutor)(implicit system: ActorSystem): ApiInvoker =
+    apply(DefaultFormats ++ Serializers.all ++ serializers, ec)
+  def apply(formats: Formats, ec: ExecutionContextExecutor)(implicit system: ActorSystem): ApiInvoker = new ApiInvoker(formats, ec)
   /**
     * Allows request execution without calling apiInvoker.execute(request)
     * request.response can be used to get a future of the ApiResponse generated.
@@ -59,10 +59,10 @@ object ApiInvoker {
 }
 trait UnitJSONSupport {
 }
-class ApiInvoker(formats: Formats)(implicit system: ActorSystem, ec: ExecutionContext) extends CustomContentTypes with Json4sSupport {
+class ApiInvoker(formats: Formats, ec: ExecutionContextExecutor)(implicit system: ActorSystem) extends CustomContentTypes with Json4sSupport {
   import {{{invokerPackage}}}.ApiInvoker._
   import {{{invokerPackage}}}.ParametersMap._
-  {{! implicit val ec: ExecutionContextExecutor = system.dispatcher }}
+  implicit val iec: ExecutionContextExecutor = ec
   implicit val jsonFormats: Formats = formats
   protected val settings: ApiSettings = ApiSettings(system)
  private implicit val serialization: Serialization = jackson.Serialization

--- a/template/scala-akka-http-client/apiInvoker.mustache
+++ b/template/scala-akka-http-client/apiInvoker.mustache
@@ -27,11 +27,11 @@ import it.pagopa.interop.commons.logging.{CanLogContextFields, ContextFieldsToLo
 import java.util.UUID
 
 object ApiInvoker {
-  def apply()(implicit system: ActorSystem): ApiInvoker =
+  def apply()(implicit system: ActorSystem, ec: ExecutionContext): ApiInvoker =
     apply(DefaultFormats ++ Serializers.all)
-  def apply(serializers: Iterable[Serializer[_]])(implicit system: ActorSystem): ApiInvoker =
+  def apply(serializers: Iterable[Serializer[_]])(implicit system: ActorSystem, ec: ExecutionContext): ApiInvoker =
     apply(DefaultFormats ++ Serializers.all ++ serializers)
-  def apply(formats: Formats)(implicit system: ActorSystem): ApiInvoker = new ApiInvoker(formats)
+  def apply(formats: Formats)(implicit system: ActorSystem, ec: ExecutionContext): ApiInvoker = new ApiInvoker(formats)
   /**
     * Allows request execution without calling apiInvoker.execute(request)
     * request.response can be used to get a future of the ApiResponse generated.
@@ -59,10 +59,10 @@ object ApiInvoker {
 }
 trait UnitJSONSupport {
 }
-class ApiInvoker(formats: Formats)(implicit system: ActorSystem) extends CustomContentTypes with Json4sSupport {
+class ApiInvoker(formats: Formats)(implicit system: ActorSystem, ec: ExecutionContext) extends CustomContentTypes with Json4sSupport {
   import {{{invokerPackage}}}.ApiInvoker._
   import {{{invokerPackage}}}.ParametersMap._
-  implicit val ec: ExecutionContextExecutor = system.dispatcher
+  {{! implicit val ec: ExecutionContextExecutor = system.dispatcher }}
   implicit val jsonFormats: Formats = formats
   protected val settings: ApiSettings = ApiSettings(system)
  private implicit val serialization: Serialization = jackson.Serialization


### PR DESCRIPTION
@beetlecrunch @galales, I would like to talk about two things:
1) Can we embed calls like this in a constructor?
```scala
object AuthorizationManagementInvoker {
    def apply()(implicit actorSystem: ActorSystem, blockingEc: ExecutionContext): AuthorizationManagementInvoker =
      authorizationmanagement.client.invoker.ApiInvoker(authorizationmanagement.client.api.EnumsSerializers.all)
  }
```
2) Can we discuss the famous non-exhausting pattern match in ApiInvoker?